### PR TITLE
Fix for `DOCS-3404: [FEEDBACK] No explanation for the Fragment Types`

### DIFF
--- a/modules/ROOT/pages/design-create-publish-api-fragment.adoc
+++ b/modules/ROOT/pages/design-create-publish-api-fragment.adoc
@@ -8,7 +8,7 @@ You can create API fragments directly in RAML with the help of code suggestions 
 
 == About this task
 
-An API fragment is a RAML document that has a version and an identifier, but is not in itself a complete RAML specification. An API fragment is one of the following types defined by RAML.org:
+An API fragment is a RAML document that has a version and an identifier, but is not in itself a complete RAML specification. An API fragment is one of the following types defined by RAML.org. See the RAML 0.8 or 1.0 specification (depending on which you want to use) for descriptions of the types and of situations in which you can use them.
 
 * Trait
 


### PR DESCRIPTION
The person who opened the ticket (which is here: https://www.mulesoft.org/jira/browse/DOCS-3404 ) asked for a "description of the types or give examples of when they would be used". I think it best to have the user refer directly to the RAML specification, rather than to repeat in this topic what the RAML spec says for each type.