### PR TITLE
Revisions to the AMF "migration guide" for 2.4.1

### DIFF
--- a/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
@@ -5,6 +5,8 @@
 
 As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation by default for RAML API-specification projects that were create before this date. If you open in the API editor a published API specification that is written in either RAML 0.8 or RAML 1.0, and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
+All of the problems listed below are among the top 10 most common (as determined by MuleSoft).
+
 [IMPORTANT]
 ====
 After a grace period that lasts at least until January 10, 2020, you will not be able to publish API specifications that generate any violation messages.

--- a/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
@@ -3,7 +3,7 @@
 [[bookmark-a,Back to the top]]
 
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in either RAML 0.8 or RAML 1.0 and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) can use stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in either RAML 0.8 or RAML 1.0, enable the stricter validation in the top-right corner of the editor, and see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
@@ -3,10 +3,13 @@
 [[bookmark-a,Back to the top]]
 
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in either RAML 0.8 or RAML 1.0 and you see error or warning indicators, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in either RAML 0.8 or RAML 1.0 and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
+[IMPORTANT]
+====
+After a grace period that lasts at least until January 10, 2020, you will not be able to publish API specifications that generate any violation messages.
+====
 
-// Review from here down
 
 == Declaring a URI parameter that is never used
 
@@ -77,13 +80,13 @@ baseUriParameters:
 
 == Not putting quotation marks around integers that are used as the names of types
 
-If an integer is used as the name of a type, but the integer is not in quotation marks, then the editor displays this error message:
+If an integer is used as the name of a type, but the integer is not in quotation marks, then the editor displays this violation message:
 
 ----
 expecting !!str and !!int provided
 ----
 
-For example, the name of the type in this specification would generate the error message:
+For example, the name of the type in this specification would generate the violation message:
 ----
 #%RAML 1.0
 title: test
@@ -102,7 +105,7 @@ types:
     type: string
 ----
 
-In the next example, the names of the examples for the type `A` are both integers and would generate this error message twice:
+In the next example, the names of the examples for the type `A` are both integers and would generate this violation message twice:
 
 ----
 #%RAML 1.0
@@ -143,7 +146,7 @@ types:
 
 == Not including a property in an example
 
-If an example is missing a property of the type that it is exemplifying, the editor displays this error message:
+If an example is missing a property of the type that it is exemplifying, the editor displays this violation message:
 
 ----
 should have required property 'property name'

--- a/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
@@ -3,7 +3,7 @@
 [[bookmark-a,Back to the top]]
 
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) can use stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in either RAML 0.8 or RAML 1.0, enable the stricter validation in the top-right corner of the editor, and see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation by default for RAML API-specification projects that were create before this date. If you open in the API editor a published API specification that is written in either RAML 0.8 or RAML 1.0, and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/design-common-problems-raml-08.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08.adoc
@@ -4,12 +4,14 @@
 
 As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation by default for RAML API-specification projects that were create before this date. If you open in the API editor a published API specification that is written in RAML 0.8, and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
+Problems that are among the top 10 most common (as determined by MuleSoft) are indicated with _Top 10:_ in their titles.
+
 [IMPORTANT]
 ====
 After a grace period that lasts at least until January 10, 2020, you will not be able to publish API specifications that generate any violation messages.
 ====
 
-== Using a reserved name for a schema
+== _Top 10:_ Using a reserved name for a schema
 
 If you use a reserved name as the name of a schema, the editor displays this message:
 ----

--- a/modules/ROOT/pages/design-common-problems-raml-08.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08.adoc
@@ -2,12 +2,53 @@
 
 [[bookmark-a,Back to the top]]
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. Therefore, it is possible that one or more of the APIs that you used previous versions of the API editor to create include invalid RAML that those previous versions did not flag. If you open in the API editor a published API specification that is written in RAML 0.8 and you see error or warning indicators, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 0.8 and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
+
+[IMPORTANT]
+====
+After a grace period that lasts at least until January 10, 2020, you will not be able to publish API specifications that generate any violation messages.
+====
+
+== Using a reserved name for a schema
+
+If you use a reserved name as the name of a schema, the editor displays this message:
+----
+‘schemaName’ cannot be used to name a custom schema
+----
+
+Examples of reserved names are `string`, `integer`, `number`, and `object`. Any name that is used in the RAML specification cannot be used as the name for a schema.
+
+For example, this API specification would cause the editor to display the message:
+
+----
+#%RAML 0.8
+
+title: Example API Spec
+
+schemas:
+ string:
+   type: string
+----
+
+To resolve the problem, you would need to use a different name in the schema declaration:
+
+----
+#%RAML 0.8
+
+title: Example API Spec
+
+schemas:
+ customString:
+   type: string
+----
+
+<<Back to the top>>
+
 
 == Not using a data type of string for the example of a Boolean enum
 // APIMF-824
 
-Whether the values for a Boolean enum are both strings or Boolean values, the example of the enum must be a string. To illustrate the error, this API specification shows an example using the wrong data type.
+Whether the values for a Boolean enum are both strings or Boolean values, the example of the enum must be a string. To illustrate the violation, this API specification shows an example using the wrong data type.
 
 ----
 #%RAML 0.8
@@ -86,7 +127,7 @@ schemas:
 == Using a non-integer data type for the example of a property that is an integer
 // APIMF-853
 
-The data type for the example of a property that is an integer must be an integer. As an example of the error, the data type of the example does not match the data type defined for `uriParameters`.
+The data type for the example of a property that is an integer must be an integer. As an example of the violation, the data type of the example does not match the data type defined for `uriParameters`.
 
 
 ----
@@ -208,7 +249,7 @@ schemas:
 == Using 0 or 1 as the value of an example of a Boolean
 // APIMF-929
 
-An example for a Boolean must have a value of "true" or "false". In this API specification illustrating the error, the value of the example for the form parameter `is_public` is incorrect.
+An example for a Boolean must have a value of "true" or "false". In this API specification illustrating the violation, the value of the example for the form parameter `is_public` is incorrect.
 
 
 ----
@@ -375,43 +416,6 @@ The path must start at the root level of the schema and descend through the tree
        "type": "object"
     }
 
-----
-
-<<Back to the top>>
-
-// Review from here down
-
-== Using a reserved name for a schema
-
-If you use a reserved name as the name of a schema, the editor displays this message:
-----
-‘schemaName’ cannot be used to name a custom schema
-----
-
-Examples of reserved names are `string`, `integer`, `number`, and `object`. Any name that is used in the RAML specification cannot be used as the name for a schema.
-
-For example, this API specification would cause the editor to display the message:
-
-----
-#%RAML 0.8
-
-title: Example API Spec
-
-schemas:
- string:
-   type: string
-----
-
-To resolve the problem, you would need to use a different name in the schema declaration:
-
-----
-#%RAML 0.8
-
-title: Example API Spec
-
-schemas:
- customString:
-   type: string
 ----
 
 <<Back to the top>>

--- a/modules/ROOT/pages/design-common-problems-raml-08.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08.adoc
@@ -2,7 +2,7 @@
 
 [[bookmark-a,Back to the top]]
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) can use stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 0.8, enable the stricter validation in the top-right corner of the editor, and see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation by default for RAML API-specification projects that were create before this date. If you open in the API editor a published API specification that is written in RAML 0.8, and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/design-common-problems-raml-08.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08.adoc
@@ -2,7 +2,7 @@
 
 [[bookmark-a,Back to the top]]
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 0.8 and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) can use stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 0.8, enable the stricter validation in the top-right corner of the editor, and see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -2,7 +2,9 @@
 
 [[bookmark-a,Back to the top]]
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 1.0 and you see error or warning indicators, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 1.0 and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
+
+
 
 == Appending references with hash symbols to filenames in `!include` statements
 // APIMF-834
@@ -154,11 +156,11 @@ Name:
     b: 1
 ----
 
-If you do not follow these rules, you will see the warning messages that are described in the next three sections.
+If you do not follow these rules, you will see the messages that are explained in the next two sections.
 
 === Not using the "examples" facet when referencing to a named example
 
-If you see this warning message in the API editor, then your API specification is incorrectly referencing a named example by using an `example` facet:
+If you see this violation message in the API editor, then your API specification is incorrectly referencing a named example by using an `example` facet:
 
 ----
 Named example fragments should be included in 'examples' facet

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -2,7 +2,7 @@
 
 [[bookmark-a,Back to the top]]
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 1.0 and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) can use stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 1.0, enable the stricter validation in the top-right corner of the editor, and see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -4,13 +4,15 @@
 
 As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation by default for RAML API-specification projects that were create before this date. If you open in the API editor a published API specification that is written in RAML 1.0, and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
+Problems that are among the top 10 most common (as determined by MuleSoft) are indicated with _Top 10:_ in their titles.
+
 [IMPORTANT]
 ====
 After a grace period that lasts at least until January 10, 2020, you will not be able to publish API specifications that generate any violation messages.
 ====
 
 
-== Using the `schema` or `schemas` keyword instead of `type` or `types`
+== _Top 10:_ Using the `schema` or `schemas` keyword instead of `type` or `types`
 
 The specification for RAML 1.0 replaced the keywords `schema` and `schemas` with `type` and `types`. If you use `schema` or `schemas`, the editor displays one of these warning messages:
 
@@ -69,7 +71,7 @@ types:
 
 <<Back to the top>>
 
-== Using a reserved name for a type
+== _Top 10:_ Using a reserved name for a type
 
 If you use a reserved name as the name of a type, the editor displays this message:
 ----

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -307,8 +307,8 @@ Name:
 ----
 
 
-
-=== Including more than one named example in a single NamedExample fragment
+////
+//=== Including more than one named example in a single NamedExample fragment
 
 A NamedExample fragment can contain only one example. The following fragment would generate a warning:
 
@@ -356,7 +356,7 @@ A single type declaration in an API specification can use only one `!include` ta
 // * `[http]` or `[HTTP]`
 // * `[https]` or `[HTTPS]`
 // * `[http, https]` or `[HTTP, HTTPS]`
-
+////
 <<Back to the top>>
 
 == Including an example response that contains invalid JSON

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -2,7 +2,7 @@
 
 [[bookmark-a,Back to the top]]
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) can use stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 1.0, enable the stricter validation in the top-right corner of the editor, and see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation by default for RAML API-specification projects that were create before this date. If you open in the API editor a published API specification that is written in RAML 1.0, and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -1,130 +1,105 @@
-= Common Errors Found in RAML 1.0 API Specifications
+= Common Problems Found in RAML 1.0 API Specifications
 
 [[bookmark-a,Back to the top]]
 
 As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. If you open in the API editor a published API specification that is written in RAML 1.0 and you see violation (red) or warning (orange) messages, this list might help you to resolve the problems in your RAML.
 
+[IMPORTANT]
+====
+After a grace period that lasts at least until January 10, 2020, you will not be able to publish API specifications that generate any violation messages.
+====
 
 
-== Appending references with hash symbols to filenames in `!include` statements
-// APIMF-834
+== Using the `schema` or `schemas` keyword instead of `type` or `types`
 
-A filename cannot be followed by a hash symbol and a reference to a location within the named file. In this example, `IncrementType.raml#increment` is not a valid link.
-
-----
-#%RAML 1.0 DataType
-
-type: object
-properties:
-  startValue: integer
-  endValue: integer
-  exclusiveEndValue: boolean
-  range:
-    type: array
-    items: !include IncrementType.raml#increment
+The specification for RAML 1.0 replaced the keywords `schema` and `schemas` with `type` and `types`. If you use `schema` or `schemas`, the editor displays one of these warning messages:
 
 ----
+‘schema' keyword it's deprecated for 1.0 version, should use 'type' instead
+----
+----
+'schemas' keyword it's deprecated for 1.0 version, should use 'types' instead
+----
 
-If your specification contains an error of this type, but you meant to write a comment, place an empty space before the "#" symbol. If you meant to reference an element that is in the file, such references are not allowed. References to inner elements are valid only for XSD and JSON schemas.
+For example, the following API specification generates both warning messages:
+
+----
+#%RAML 1.0
+title: Incorrect API with schema and schemas
+
+schemas:
+ User:
+   type: object
+   properties:
+     firstname: string
+     lastname:  string
+     age:       number
+
+/users/{id}:
+ get:
+   responses:
+     200:
+       body:
+         application/json:
+           schema: User
+----
+
+To resolve the problem, you would replace `schema` and `schemas` with `type` and `types`:
+
+----
+#%RAML 1.0
+title: Correct API with type and types
+
+types:
+ User:
+   type: object
+   properties:
+     firstname: string
+     lastname:  string
+     age:       number
+
+/users/{id}:
+ get:
+   responses:
+     200:
+       body:
+         application/json:
+           type: User
+----
 
 <<Back to the top>>
 
-== Not correctly using curly braces and brackets in JSON examples
-// APIMF-849
+== Using a reserved name for a type
 
-There are many ways to misuse curly braces and brackets. This example illustrates one of them. An array of groups of JSON key/value pairs is improperly enclosed in a pair of curly braces.
+If you use a reserved name as the name of a type, the editor displays this message:
+----
+‘typeName’ cannot be used to name a custom type
+----
+
+Examples of reserved names are `string`, `object`, `integer`, `number`, and `object`. Any name that is used in the RAML specification cannot be used as the name for a type.
+
+For example, this API specification would cause the editor to display the message:
 
 ----
 #%RAML 1.0
-title: ExampleRAML
-...
-/rooms:
-  displayName: rooms
-  get:
-    description: get all rooms
-    responses:
-      200:
-        body:
-          application/json:
-            example: |
-             {
-               [{
-                "Name": "Superior King",
-                "Number": "201",
-                "Property": "SE030",
-                "Status": "Clean"
-                },
-                {
-                "Name": "Junior Suite",
-                "Number": "202",
-                "Property": "NO131",
-                "Status": "Clean"
-                }]
-              }
+
+title: Example API Spec
+
+types:
+ string:
+   type: string
 ----
 
-If the example was meant be an object, then a key must be specified for it.
+To resolve the problem, you would need to use a different name in the type declaration:
 
 ----
 #%RAML 1.0
-title: ExampleRAML
-...
-/rooms:
-  displayName: rooms
-  get:
-    description: get all rooms
-    responses:
-      200:
-        body:
-          application/json:
-            example:
-            {
-    	      "some_key": [
-                {
-                  "Name": "Superior King",
-          	  "Number": "201",
-          	  "Property": "SE030",
-          	  "Status": "Clean"
-          	},
-          	{
-          	  "Name": "Junior Suite",
-          	  "Number": "202",
-          	  "Property": "NO131",
-          	  "Status": "Clean"
-          	}
-              ]
-            }
-----
 
-If the example was meant be an array, then the outside curly braces must be removed.
+title: Example API Spec
 
-----
-#%RAML 1.0
-title: ExampleRAML
-...
-/rooms:
-  displayName: rooms
-  get:
-    description: get all rooms
-    responses:
-      200:
-        body:
-          application/json:
-            example:
-            [
-                {
-                  "Name": "Superior King",
-          	  "Number": "201",
-          	  "Property": "SE030",
-          	  "Status": "Clean"
-          	},
-          	{
-          	  "Name": "Junior Suite",
-          	  "Number": "202",
-          	  "Property": "NO131",
-          	  "Status": "Clean"
-          	}
-            ]
+types:
+ customString:
+   type: string
 ----
 
 <<Back to the top>>
@@ -361,10 +336,136 @@ A single type declaration in an API specification can use only one `!include` ta
 ////
 <<Back to the top>>
 
+
+== Appending references with hash symbols to filenames in `!include` statements
+// APIMF-834
+
+A filename cannot be followed by a hash symbol and a reference to a location within the named file. In this example, `IncrementType.raml#increment` is not a valid link.
+
+----
+#%RAML 1.0 DataType
+
+type: object
+properties:
+  startValue: integer
+  endValue: integer
+  exclusiveEndValue: boolean
+  range:
+    type: array
+    items: !include IncrementType.raml#increment
+
+----
+
+If your specification contains an violation of this type, but you meant to write a comment, place an empty space before the "#" symbol. If you meant to reference an element that is in the file, such references are not allowed. References to inner elements are valid only for XSD and JSON schemas.
+
+<<Back to the top>>
+
+== Not correctly using curly braces and brackets in JSON examples
+// APIMF-849
+
+There are many ways to misuse curly braces and brackets. This example illustrates one of them. An array of groups of JSON key/value pairs is improperly enclosed in a pair of curly braces.
+
+----
+#%RAML 1.0
+title: ExampleRAML
+...
+/rooms:
+  displayName: rooms
+  get:
+    description: get all rooms
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+             {
+               [{
+                "Name": "Superior King",
+                "Number": "201",
+                "Property": "SE030",
+                "Status": "Clean"
+                },
+                {
+                "Name": "Junior Suite",
+                "Number": "202",
+                "Property": "NO131",
+                "Status": "Clean"
+                }]
+              }
+----
+
+If the example was meant be an object, then a key must be specified for it.
+
+----
+#%RAML 1.0
+title: ExampleRAML
+...
+/rooms:
+  displayName: rooms
+  get:
+    description: get all rooms
+    responses:
+      200:
+        body:
+          application/json:
+            example:
+            {
+    	      "some_key": [
+                {
+                  "Name": "Superior King",
+          	  "Number": "201",
+          	  "Property": "SE030",
+          	  "Status": "Clean"
+          	},
+          	{
+          	  "Name": "Junior Suite",
+          	  "Number": "202",
+          	  "Property": "NO131",
+          	  "Status": "Clean"
+          	}
+              ]
+            }
+----
+
+If the example was meant be an array, then the outside curly braces must be removed.
+
+----
+#%RAML 1.0
+title: ExampleRAML
+...
+/rooms:
+  displayName: rooms
+  get:
+    description: get all rooms
+    responses:
+      200:
+        body:
+          application/json:
+            example:
+            [
+                {
+                  "Name": "Superior King",
+          	  "Number": "201",
+          	  "Property": "SE030",
+          	  "Status": "Clean"
+          	},
+          	{
+          	  "Name": "Junior Suite",
+          	  "Number": "202",
+          	  "Property": "NO131",
+          	  "Status": "Clean"
+          	}
+            ]
+----
+
+<<Back to the top>>
+
+
+
 == Including an example response that contains invalid JSON
 // APIMF-967
 
-When a JSON file is included as the example of a response message, the JSON in the file must be valid. In this example of the error, the example of the response for the 200 response code contains an `!include` statement. The JSON in the included file incorrectly contains a comma after the last key/value pair.
+When a JSON file is included as the example of a response message, the JSON in the file must be valid. In this example of the violation, the example of the response for the 200 response code contains an `!include` statement. The JSON in the included file incorrectly contains a comma after the last key/value pair.
 
 ----
 #%RAML 1.0
@@ -447,7 +548,7 @@ uses:
 == Specifying values for an enum that does not match the enum's data type
 // APIMF-1062
 
-Because of the editor's strict parsing according to the YAML specification, it does not automatically cast values to declared data types. To illustrate the error, here is an invalid declaration of an enum:
+Because of the editor's strict parsing according to the YAML specification, it does not automatically cast values to declared data types. To illustrate the violation, here is an invalid declaration of an enum:
 
 ----
 type: string
@@ -495,7 +596,7 @@ enum: [
 
 [NOTE]
 ===
-This error can occur not just in enums, but also anywhere an `integer`, `nil` value, or value of some other data type is introduced where the parser expects a `string` value.
+This violation can occur not just in enums, but also anywhere an `integer`, `nil` value, or value of some other data type is introduced where the parser expects a `string` value.
 ===
 
 <<Back to the top>>
@@ -503,7 +604,7 @@ This error can occur not just in enums, but also anywhere an `integer`, `nil` va
 == Using, in an example of a numeric type, an incorrect format for that type, if a format is specified
 // APIMF-1070
 
-Examples of numeric types must conform to restrictions specified in the `format` node. In this example of the error, the format specified for the numeric type `collection` is int8. However, the value of the example is greater than 127.
+Examples of numeric types must conform to restrictions specified in the `format` node. In this example of the violation, the format specified for the numeric type `collection` is int8. However, the value of the example is greater than 127.
 
 ----
 #%RAML 1.0
@@ -520,102 +621,6 @@ types:
        body:
         type: collection
         example: 22342342
-----
-
-<<Back to the top>>
-
-// Review from here down
-
-== Using the `schema` or `schemas` keyword instead of `type` or `types`
-
-The specification for RAML 1.0 replaced the keywords `schema` and `schemas` with `type` and `types`. If you use `schema` or `schemas`, the editor displays one of these warning messages:
-
-----
-‘schema' keyword it's deprecated for 1.0 version, should use 'type' instead
-----
-----
-'schemas' keyword it's deprecated for 1.0 version, should use 'types' instead
-----
-
-For example, the following API specification generates both warning messages:
-
-----
-#%RAML 1.0
-title: Incorrect API with schema and schemas
-
-schemas:
- User:
-   type: object
-   properties:
-     firstname: string
-     lastname:  string
-     age:       number
-
-/users/{id}:
- get:
-   responses:
-     200:
-       body:
-         application/json:
-           schema: User
-----
-
-To resolve the problem, you would replace `schema` and `schemas` with `type` and `types`:
-
-----
-#%RAML 1.0
-title: Correct API with type and types
-
-types:
- User:
-   type: object
-   properties:
-     firstname: string
-     lastname:  string
-     age:       number
-
-/users/{id}:
- get:
-   responses:
-     200:
-       body:
-         application/json:
-           type: User
-----
-
-<<Back to the top>>
-
-== Using a reserved name for a type
-
-If you use a reserved name as the name of a type, the editor displays this message:
-----
-‘typeName’ cannot be used to name a custom type
-----
-
-Examples of reserved names are `string`, `object`, `integer`, `number`, and `object`. Any name that is used in the RAML specification cannot be used as the name for a type.
-
-For example, this API specification would cause the editor to display the message:
-
-----
-#%RAML 1.0
-
-title: Example API Spec
-
-types:
- string:
-   type: string
-----
-
-To resolve the problem, you would need to use a different name in the type declaration:
-
-----
-#%RAML 1.0
-
-title: Example API Spec
-
-types:
- customString:
-   type: string
 ----
 
 <<Back to the top>>

--- a/modules/ROOT/pages/design-create-publish-api-raml-editor.adoc
+++ b/modules/ROOT/pages/design-create-publish-api-raml-editor.adoc
@@ -46,7 +46,9 @@ For more information, view the topic "Simulate Calls to an API", which is linked
 
 Export your API project or specification:: At any time, you can export your project as a `.zip` file. Next to the *Files* heading in the left pane, click the dots and select *Export*.
 
-Download files:: You can either download a file as is, or you can download it in another format. For example, you can download a file written in RAML 0.8 as a file in OAS 2.0 YAML. Click the dots to the right of the file name and select *Download* or *Download As*.
+Download files:: Click the dots to the right of the file name and select *Download*.
+
+// Download files:: You can either download a file as is, or you can download it in another format. For example, you can download a file written in RAML 0.8 as a file in OAS 2.0 YAML. Click the dots to the right of the file name and select *Download* or *Download As*.
 
 Convert files:: Convert a file in your project to another format. Click the dots to the right of the file name and select *Convert*.
 

--- a/modules/ROOT/pages/design-modify-raml-specs-conform.adoc
+++ b/modules/ROOT/pages/design-modify-raml-specs-conform.adoc
@@ -2,19 +2,19 @@
 
 [[bookmark-a,Back to the top]]
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. Therefore, it is possible that one or more of the APIs that you used previous versions of the API editor to create include invalid RAML that those previous versions did not flag.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) can use stricter validation for specifications that are written in RAML. Therefore, it is possible that one or more of the APIs that you used previous versions of the API editor to create include invalid RAML that those previous versions did not flag.
 
-Check your published APIs by opening them in the API editor in Design Center. You can use this guide to correct a number of common RAML problems that were validated by the API editor in the past. If you see problems that this guide does not include, refer to the specifications for RAML 0.8 and 1.0, which you can read on https://raml.org/[raml.org].
+Check your published APIs by opening them in the API editor in Design Center and enabling stricter validation in the top-right corner of the editor. You can use this guide to correct a number of common RAML problems that were validated by the API editor in the past but that are now generating messages. If you see problems that this guide does not include, refer to the specifications for RAML 0.8 and 1.0, which you can read on https://raml.org/[raml.org].
+
+* xref:design-common-problems-raml-08.adoc[Common Problems in Conforming to RAML 0.8]
+* xref:design-common-problems-raml-10.adoc[Common Problems in Conforming to RAML 1.0]
+* xref:design-common-problems-raml-08-10.adoc[Common Problems in Conforming Either to RAML 0.8 or 1.0]
 
 In addition to checking more precisely for RAML problems, the API editor also validates regular expressions. Any invalid expressions in published API specifications that you reopen in the editor are now flagged as errors.
 
-You have a long grace period to correct any invalid RAML and invalid regular expressions that your published API specifications might include. After the grace period expires, you will be unable to republish and redeploy API specifications in which such problems still exist.
+You have a long grace period -- at least until January 10, 2020 -- to correct any invalid RAML and invalid regular expressions that your published API specifications might include. After the grace period expires, you will be unable to republish and redeploy API specifications in which such problems still exist.
 
 [IMPORTANT]
 ====
 You do not need to check any API specifications that were created with the visual API editor, the tool in API Designer with which you can create specifications by filling in forms.
 ====
-
-* xref:design-common-problems-raml-08.adoc[Common Problems in Conforming to RAML 0.8]
-* xref:design-common-problems-raml-10.adoc[Common Problems in Conforming to RAML 1.0]
-* xref:design-common-problems-raml-08-10.adoc[Common Problems in Conforming Either to RAML 0.8 or 1.0]

--- a/modules/ROOT/pages/design-modify-raml-specs-conform.adoc
+++ b/modules/ROOT/pages/design-modify-raml-specs-conform.adoc
@@ -2,7 +2,7 @@
 
 [[bookmark-a,Back to the top]]
 
-As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) can use stricter validation for specifications that are written in RAML. Therefore, it is possible that one or more of the APIs that you used previous versions of the API editor to create include invalid RAML that those previous versions did not flag.
+As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation by default for RAML API-specification projects that were create before this date. Therefore, it is possible that one or more of the APIs that you used previous versions of the API editor to create include invalid RAML that those previous versions did not flag.
 
 Check your published APIs by opening them in the API editor in Design Center and enabling stricter validation in the top-right corner of the editor. You can use this guide to correct a number of common RAML problems that were validated by the API editor in the past but that are now generating messages. If you see problems that this guide does not include, refer to the specifications for RAML 0.8 and 1.0, which you can read on https://raml.org/[raml.org].
 

--- a/modules/ROOT/pages/design-modify-raml-specs-conform.adoc
+++ b/modules/ROOT/pages/design-modify-raml-specs-conform.adoc
@@ -4,9 +4,9 @@
 
 As of January 10, 2019, the API editor (one of the two editors in Design Center's API Designer) uses stricter validation for specifications that are written in RAML. Therefore, it is possible that one or more of the APIs that you used previous versions of the API editor to create include invalid RAML that those previous versions did not flag.
 
-Check your published APIs by opening them in the API editor in Design Center. You can use this guide to correct a number of common RAML problems that were validated by the API editor in the past. If you see errors that this guide does not include, refer to the specifications for RAML 0.8 and 1.0, which you can read on https://raml.org/[raml.org].
+Check your published APIs by opening them in the API editor in Design Center. You can use this guide to correct a number of common RAML problems that were validated by the API editor in the past. If you see problems that this guide does not include, refer to the specifications for RAML 0.8 and 1.0, which you can read on https://raml.org/[raml.org].
 
-In addition to checking more precisely for RAML errors, the API editor also validates regular expressions. Any invalid expressions in published API specifications that you reopen in the editor are now flagged as errors.
+In addition to checking more precisely for RAML problems, the API editor also validates regular expressions. Any invalid expressions in published API specifications that you reopen in the editor are now flagged as errors.
 
 You have a long grace period to correct any invalid RAML and invalid regular expressions that your published API specifications might include. After the grace period expires, you will be unable to republish and redeploy API specifications in which such problems still exist.
 


### PR DESCRIPTION
Changes:

- In the write-up for named examples that is in design-common-problems-raml-10.adoc, I removed this problem" "Including more than one named example in a single NamedExample fragment". I also revised this problem to make it clear that it generates a violation message: "Not using the "examples" facet when referencing to a named example".

- I explained better the difference between the types of warnings.

- I mentioned the feature for switching stricter validation on and off.

- I noted which problems are among the top 10 most common.