### PR TITLE
DOCS-3887 Comment out the paragraph on viewing files in other formats

### DIFF
--- a/modules/ROOT/pages/design-create-publish-api-raml-editor.adoc
+++ b/modules/ROOT/pages/design-create-publish-api-raml-editor.adoc
@@ -52,7 +52,7 @@ Download files:: Click the dots to the right of the file name and select *Downlo
 
 Convert files:: Convert a file in your project to another format. Click the dots to the right of the file name and select *Convert*.
 
-View files in other formats:: See what a file would look like in another format. For example, see what an OAS 2.0 JSON file would look like in RAML 1.0. Click the dots to the right of the file name and select *View As*.
+// View files in other formats:: See what a file would look like in another format. For example, see what an OAS 2.0 JSON file would look like in RAML 1.0. Click the dots to the right of the file name and select *Copy As*.
 
 
 


### PR DESCRIPTION
Closing out this [ticket](https://www.mulesoft.org/jira/browse/DOCS-3887) by commenting out the paragraph that the ticket mentions. The menu item is really *Copy As*; however, this feature produces incorrect files. I'm not sure why it is in the product. I've been asking the APID team what is the benefit to users of generating a file that they cannot do anything with and that is highly likely to be incorrect; nobody on that team has replied.