### PR TITLE
DOCS-3855 Moving JSON problems to the file for both specs

### DIFF
--- a/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08-10.adoc
@@ -398,3 +398,128 @@ Libraries must be applied by using 'uses'
 
 
 <<Back to the top>>
+
+
+
+
+== Including a schema that contains invalid JSON
+// APIMF-841
+
+The JSON in files that are included in the value of the `schemas` property must be valid.
+
+The first example includes the schema `appSwitcher.json`. However, the second shows that there is an error in the JSON: at the end of the last value, there is a comma, though there should instead be a quotation mark.
+
+
+----
+#%RAML 0.8
+title: ExampleRAML
+schemas:
+  - appSwitcher: !include schemas/appSwitcher.json
+----
+
+
+----
+{
+  "appMenuItems" : [
+    {
+      "type" : "Tabset" ,
+      "content" : null ,
+      "icons" : null ,
+      "colors" : null ,
+      "label" : "Call Center" ,
+      "url" : "/home/home.jsp?tsid=02uxx00000056Sr"
+    } , {
+      "type" : "Tabset" ,
+      "content" : null ,
+      "icons" : null ,
+      "colors" : null ,
+      "label" : "Community" ,
+      "url" : "/home/home.jsp?tsid=02uxx00000056Sw"
+    } , {
+      "type" : "Tabset" ,
+      "content" : null ,
+      "icons" : null ,
+      "colors" : null ,
+      "label" : "App Launcher" ,
+      "url" : "/app/mgmt/applauncher/appLauncher.apexp?tsid=02uxx00000056Sx,
+    }
+  ]
+}
+----
+
+<<Back to the top>>
+
+== Using invalid JSON in examples of JSON schemas
+// APIMF-1069
+
+Examples of JSON schemas must be valid, unlike the example in the following API specification:
+
+
+----
+#%RAML 0.8
+title: ExampleRAML
+...
+/api:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            schema:
+              {
+                "type": "object",
+                "required": true,
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "properties": {
+                  "a": {
+                    "type": "boolean",
+                    "required": true
+                  }
+                }
+              }
+            example:
+              {
+                "a: {
+                  "a": ""
+                }
+----
+
+
+<<Back to the top>>
+
+
+== Including an example response that contains invalid JSON
+// APIMF-967
+
+When a JSON file is included as the example of a response message, the JSON in the file must be valid. In this example of the violation, the example of the response for the 200 response code contains an `!include` statement. The JSON in the included file incorrectly contains a comma after the last key/value pair.
+
+----
+#%RAML 1.0
+title: ExampleRAML
+...
+/resume:
+  description: "Gets candidate's resume."
+  get:
+    queryParameters:
+       ...
+    headers:
+      ...
+    responses:
+      200:
+        body:
+          application/json:
+            example: !include exampleResumeData-200.json
+      500:
+        ...
+----
+
+
+----
+{
+...
+"assesments.characteristic.focusofattention.data"= "",
+}
+
+----
+
+<<Back to the top>>

--- a/modules/ROOT/pages/design-common-problems-raml-08.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08.adoc
@@ -79,52 +79,6 @@ The last two line of the example RAML above should then be as they are in this c
 
 <<Back to the top>>
 
-== Including a schema that contains invalid JSON
-// APIMF-841
-
-The JSON in files that are included in the value of the `schemas` property must be valid.
-
-The first example includes the schema `appSwitcher.json`. However, the second shows that there is an error in the JSON: at the end of the last value, there is a comma, though there should instead be a quotation mark.
-
-
-----
-#%RAML 0.8
-title: ExampleRAML
-schemas:
-  - appSwitcher: !include schemas/appSwitcher.json
-----
-
-
-----
-{
-  "appMenuItems" : [
-    {
-      "type" : "Tabset" ,
-      "content" : null ,
-      "icons" : null ,
-      "colors" : null ,
-      "label" : "Call Center" ,
-      "url" : "/home/home.jsp?tsid=02uxx00000056Sr"
-    } , {
-      "type" : "Tabset" ,
-      "content" : null ,
-      "icons" : null ,
-      "colors" : null ,
-      "label" : "Community" ,
-      "url" : "/home/home.jsp?tsid=02uxx00000056Sw"
-    } , {
-      "type" : "Tabset" ,
-      "content" : null ,
-      "icons" : null ,
-      "colors" : null ,
-      "label" : "App Launcher" ,
-      "url" : "/app/mgmt/applauncher/appLauncher.apexp?tsid=02uxx00000056Sx,
-    }
-  ]
-}
-----
-
-<<Back to the top>>
 
 == Using a non-integer data type for the example of a property that is an integer
 // APIMF-853
@@ -308,43 +262,6 @@ title: ExampleRAML
 
 <<Back to the top>>
 
-== Using invalid JSON in examples of JSON schemas
-// APIMF-1069
-
-Examples of JSON schemas must be valid, unlike the example in the following API specification:
-
-
-----
-#%RAML 0.8
-title: ExampleRAML
-...
-/api:
-  get:
-    responses:
-      200:
-        body:
-          application/json:
-            schema:
-              {
-                "type": "object",
-                "required": true,
-                "$schema": "http://json-schema.org/draft-03/schema",
-                "properties": {
-                  "a": {
-                    "type": "boolean",
-                    "required": true
-                  }
-                }
-              }
-            example:
-              {
-                "a: {
-                  "a": ""
-                }
-----
-
-
-<<Back to the top>>
 
 == Not providing a value for the `title` node
 // APIMF-1083

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -464,42 +464,6 @@ title: ExampleRAML
 
 
 
-== Including an example response that contains invalid JSON
-// APIMF-967
-
-When a JSON file is included as the example of a response message, the JSON in the file must be valid. In this example of the violation, the example of the response for the 200 response code contains an `!include` statement. The JSON in the included file incorrectly contains a comma after the last key/value pair.
-
-----
-#%RAML 1.0
-title: ExampleRAML
-...
-/resume:
-  description: "Gets candidate's resume."
-  get:
-    queryParameters:
-       ...
-    headers:
-      ...
-    responses:
-      200:
-        body:
-          application/json:
-            example: !include exampleResumeData-200.json
-      500:
-        ...
-----
-
-
-----
-{
-...
-"assesments.characteristic.focusofattention.data"= "",
-}
-
-
-----
-
-<<Back to the top>>
 
 == Referencing libraries by using the `type` key
 // APIMF-1030


### PR DESCRIPTION
In DOCS-3855, Lucas asked for this change:
_Disambiguate JSON invalid validations between specs, today in the documentation these validations are separated between the ramls specs.
They apply for both raml specs, so no need to differentiate them._

_- https://docs.mulesoft.com/design-center/design-common-problems-raml-08#including-a-schema-that-contains-invalid-json
- https://docs.mulesoft.com/design-center/design-common-problems-raml-08#using-invalid-json-in-examples-of-json-schemas
- https://docs.mulesoft.com/design-center/design-common-problems-raml-10#including-an-example-response-that-contains-invalid-json_

For APID 2.4.1, I created this file for problems in API specs that are written in RAML 0.8 or RAML 1.0:
https://docs.mulesoft.com/design-center/design-common-problems-raml-08-10
I've moved the three sections that Lucas listed into that new file.