### PR TITLE
[DESIGNER-3646] Design center validation inline docs

### DIFF
--- a/modules/ROOT/pages/design-common-problems-raml-08.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08.adoc
@@ -10,6 +10,7 @@ As of January 10, 2019, the API editor (one of the two editors in Design Center'
 After a grace period that lasts at least until January 10, 2020, you will not be able to publish API specifications that generate any violation messages.
 ====
 
+[.parser\*invalid-type-definition#parser\*invalid-type-definition]
 == Using a reserved name for a schema
 
 If you use a reserved name as the name of a schema, the editor displays this message:
@@ -242,7 +243,7 @@ title: ExampleRAML
 
 <<Back to the top>>
 
-
+[.parser\*WebAPI-name-minLength#parser\*WebAPI-name-minLength]
 == Not providing a value for the `title` node
 // APIMF-1083
 
@@ -277,6 +278,7 @@ title: ExampleRAML
 
 <<Back to the top>>
 
+[.parser\*unresolved-reference#parser\*unresolved-reference]
 == Using an invalid path for a reference inside a JSON schema
 // APIMF-833
 
@@ -319,6 +321,7 @@ The path must start at the root level of the schema and descend through the tree
 
 <<Back to the top>>
 
+[.parser\*unused-base-uri-parameter#parser\*unused-base-uri-parameter]
 == Declaring a URI parameter that is never used
 // Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
 // How should the examples change for RAML 0.8?
@@ -389,7 +392,7 @@ baseUriParameters:
 <<Back to the top>>
 
 
-
+[.parser\*Payload-mediaType-minCount#parser\*Payload-mediaType-minCount]
 == Not declaring a media type for a payload
 // Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
 
@@ -745,6 +748,7 @@ securitySchemes:
 
 <<Back to the top>>
 
+[.parser\*closed-shape#parser\*closed-shape]
 == Using an unsupported property
 
 This error occurs if you use an undefined facet.
@@ -778,7 +782,7 @@ version:
 
 <<Back to the top>>
 
-
+[.parser\*unresolved-parameter#parser\*unresolved-parameter]
 == Declaring an undefined type in a header
 
 This error occurs when a non-existent type is specified in a header.

--- a/modules/ROOT/pages/design-common-problems-raml-08.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-08.adoc
@@ -46,8 +46,9 @@ schemas:
 
 <<Back to the top>>
 
-
-== Not using a data type of string for the example of a Boolean enum
+[.parser\*example-validation-error#parser\*example-validation-error]
+== Problems when validating examples
+=== Not using a data type of string for the example of a Boolean enum
 // APIMF-824
 
 Whether the values for a Boolean enum are both strings or Boolean values, the example of the enum must be a string. To illustrate the violation, this API specification shows an example using the wrong data type.
@@ -79,8 +80,7 @@ The last two line of the example RAML above should then be as they are in this c
 
 <<Back to the top>>
 
-
-== Not using a required property in the example of a schema that defines that property
+=== Not using a required property in the example of a schema that defines that property
 // APIMF-896
 
 If a schema defines a required property, the example of that schema must use that property. In this example of the problem, the following API specification defines a response for the endpoint `/order/{id}`. The definition includes two files: `get_order_response_schema.json` and `get_order_response.json`.
@@ -183,7 +183,7 @@ schemas:
 
 <<Back to the top>>
 
-== Using 0 or 1 as the value of an example of a Boolean
+=== Using 0 or 1 as the value of an example of a Boolean
 // APIMF-929
 
 An example for a Boolean must have a value of "true" or "false". In this API specification illustrating the violation, the value of the example for the form parameter `is_public` is incorrect.
@@ -206,6 +206,127 @@ title: ExampleRAML
             type: boolean
             example: 1
 ----
+
+=== Not including a property in an example
+// Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
+// How should the examples change for RAML 0.8?
+
+If an example is missing a property of the type that it is exemplifying, the editor displays this violation message:
+
+----
+should have required property 'property name'
+----
+
+For example, the property `age` is missing in the example:
+
+----
+#%RAML 0.8
+title: Example API Spec
+
+/clients:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "properties": {
+                    "firstName": {
+                      "type": "string"
+                    },
+                    "lastName": {
+                      "type": "string"
+                    },
+                    "age": {
+                      "type": "number",
+                      "required": true
+                    }
+                },
+                "required": false,
+                "type": "object"
+              }
+            example:
+              firstName: John
+              lastName: Smith
+----
+
+Either add the property to the example or, in the type declaration, declare the property as optional.
+
+In this case, the property is added to the example:
+
+----
+#%RAML 0.8
+title: Example API Spec
+
+/clients:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "properties": {
+                    "firstName": {
+                      "type": "string"
+                    },
+                    "lastName": {
+                      "type": "string"
+                    },
+                    "age": {
+                      "type": "number",
+                      "required": true
+                    }
+                },
+                "required": false,
+                "type": "object"
+              }
+            example:
+              firstName: John
+              lastName: Smith
+              age: 30
+----
+
+In this case, the property is declared as optional:
+
+----
+#%RAML 0.8
+title: Example API Spec
+
+/clients:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            schema: |
+              {
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "properties": {
+                    "firstName": {
+                      "type": "string"
+                    },
+                    "lastName": {
+                      "type": "string"
+                    },
+                    "age": {
+                      "type": "number",
+                      "required": false
+                    }
+                },
+                "required": false,
+                "type": "object"
+              }
+            example:
+              firstName: John
+              lastName: Smith
+----
+
+<<Back to the top>>
+
 
 // == Common Error 7
 // APIMF-1023
@@ -494,8 +615,9 @@ Libraries must be applied by using 'uses'
 
 <<Back to the top>>
 
-
-== Including a schema that contains invalid JSON
+[.parser\*syaml-error#parser\*syaml-error]
+== Problems with syntax
+=== Including a schema that contains invalid JSON
 // APIMF-841
 // Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
 
@@ -544,7 +666,7 @@ schemas:
 
 <<Back to the top>>
 
-== Using invalid JSON in examples of JSON schemas
+=== Using invalid JSON in examples of JSON schemas
 // APIMF-1069
 // Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
 
@@ -584,127 +706,7 @@ title: ExampleRAML
 
 <<Back to the top>>
 
-== Not including a property in an example
-// Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
-// How should the examples change for RAML 0.8?
-
-If an example is missing a property of the type that it is exemplifying, the editor displays this violation message:
-
-----
-should have required property 'property name'
-----
-
-For example, the property `age` is missing in the example:
-
-----
-#%RAML 0.8
-title: Example API Spec
-
-/clients:
-  get:
-    responses:
-      200:
-        body:
-          application/json:
-            schema: |
-              {
-                "$schema": "http://json-schema.org/draft-03/schema",
-                "properties": {
-                    "firstName": {
-                      "type": "string"
-                    },
-                    "lastName": {
-                      "type": "string"
-                    },
-                    "age": {
-                      "type": "number",
-                      "required": true
-                    }
-                },
-                "required": false,
-                "type": "object"
-              }
-            example:
-              firstName: John
-              lastName: Smith
-----
-
-Either add the property to the example or, in the type declaration, declare the property as optional.
-
-In this case, the property is added to the example:
-
-----
-#%RAML 0.8
-title: Example API Spec
-
-/clients:
-  get:
-    responses:
-      200:
-        body:
-          application/json:
-            schema: |
-              {
-                "$schema": "http://json-schema.org/draft-03/schema",
-                "properties": {
-                    "firstName": {
-                      "type": "string"
-                    },
-                    "lastName": {
-                      "type": "string"
-                    },
-                    "age": {
-                      "type": "number",
-                      "required": true
-                    }
-                },
-                "required": false,
-                "type": "object"
-              }
-            example:
-              firstName: John
-              lastName: Smith
-              age: 30
-----
-
-In this case, the property is declared as optional:
-
-----
-#%RAML 0.8
-title: Example API Spec
-
-/clients:
-  get:
-    responses:
-      200:
-        body:
-          application/json:
-            schema: |
-              {
-                "$schema": "http://json-schema.org/draft-03/schema",
-                "properties": {
-                    "firstName": {
-                      "type": "string"
-                    },
-                    "lastName": {
-                      "type": "string"
-                    },
-                    "age": {
-                      "type": "number",
-                      "required": false
-                    }
-                },
-                "required": false,
-                "type": "object"
-              }
-            example:
-              firstName: John
-              lastName: Smith
-----
-
-<<Back to the top>>
-
-== Not providing a YAML map when a facet requires one
+=== Not providing a YAML map when a facet requires one
 
 When a facet is described in the RAML 0.8 specification as requiring a map as a value, but the API specification doesn't provide a map, the editor returns the message `YAML map expected`.
 

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -511,7 +511,9 @@ uses:
 
 <<Back to the top>>
 
-== Specifying values for an enum that does not match the enum's data type
+[.parser\*example-validation-error#parser\*example-validation-error]
+== Problems when validating examples
+=== Specifying values for an enum that does not match the enum's data type
 // APIMF-1062
 
 Because of the editor's strict parsing according to the YAML specification, it does not automatically cast values to declared data types. To illustrate the violation, here is an invalid declaration of an enum:
@@ -567,7 +569,7 @@ This violation can occur not just in enums, but also anywhere an `integer`, `nil
 
 <<Back to the top>>
 
-== Using, in an example of a numeric type, an incorrect format for that type, if a format is specified
+=== Using, in an example of a numeric type, an incorrect format for that type, if a format is specified
 // APIMF-1070
 
 Examples of numeric types must conform to restrictions specified in the `format` node. In this example of the violation, the format specified for the numeric type `collection` is int8. However, the value of the example is greater than 127.
@@ -575,7 +577,6 @@ Examples of numeric types must conform to restrictions specified in the `format`
 ----
 #%RAML 1.0
 title: ExampleRAML
-...
 types:
   collection:
     type: integer
@@ -583,10 +584,100 @@ types:
 
 /search:
   /code:
-      get:
-       body:
-        type: collection
-        example: 22342342
+    get:
+      body:
+        application/json:
+          type: collection
+          example: 22342342
+----
+
+<<Back to the top>>
+
+=== Including undeclared properties in an example when additionalProperties is set to `false`
+// Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
+
+If an example for a type includes one or more properties that were not in the type declaration, the editor displays this message:
+
+----
+should NOT have additional properties
+----
+
+The editor would display this message for the following API specification:
+
+----
+#%RAML 1.0
+title: Example API Spec
+
+types:
+ User:
+   type: object
+   additionalProperties: false
+   properties:
+     firstName: string
+     lastName: string
+   example:
+     firstName: John
+     lastName: Smith
+     age: 49
+----
+
+There are three different methods that you can choose from to resolve the problem:
+
+* Delete the extra property from the example
++
+----
+#%RAML 1.0
+title: Example API Spec
+
+types:
+ User:
+   type: object
+   additionalProperties: false
+   properties:
+     firstName: string
+     lastName: string
+   example:
+     firstName: John
+     lastName: Smith
+----
+
+* Add the property in the type declaration.
++
+----
+#%RAML 1.0
+title: Example API Spec
+
+types:
+ User:
+   type: object
+   additionalProperties: false
+   properties:
+     firstName: string
+     lastName: string
+     age: integer
+   example:
+     firstName: John
+     lastName: Smith
+     age: 49
+----
+
+* Change the value of `additionalProperties` to `true` or remove the line for `additionalProperties` (because `additionalProperties` is `true` by default).
++
+----
+#%RAML 1.0
+title: Example API Spec
+
+types:
+ User:
+   type: object
+   properties:
+     firstName: string
+     lastName: string
+   additionalProperties: true
+   example:
+     firstName: John
+     lastName: Smith
+     age: 49
 ----
 
 <<Back to the top>>
@@ -729,96 +820,6 @@ types:
 
 <<Back to the top>>
 
-
-== Including undeclared properties in an example when additionalProperties is set to `false`
-// Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
-
-If an example for a type includes one or more properties that were not in the type declaration, the editor displays this message:
-
-----
-should NOT have additional properties
-----
-
-The editor would display this message for the following API specification:
-
-----
-#%RAML 1.0
-title: Example API Spec
-
-types:
- User:
-   type: object
-   additionalProperties: false
-   properties:
-     firstName: string
-     lastName: string
-   example:
-     firstName: John
-     lastName: Smith
-     age: 49
-----
-
-There are three different methods that you can choose from to resolve the problem:
-
-* Delete the extra property from the example
-+
-----
-#%RAML 1.0
-title: Example API Spec
-
-types:
- User:
-   type: object
-   additionalProperties: false
-   properties:
-     firstName: string
-     lastName: string
-   example:
-     firstName: John
-     lastName: Smith
-----
-
-* Add the property in the type declaration.
-+
-----
-#%RAML 1.0
-title: Example API Spec
-
-types:
- User:
-   type: object
-   additionalProperties: false
-   properties:
-     firstName: string
-     lastName: string
-     age: integer
-   example:
-     firstName: John
-     lastName: Smith
-     age: 49
-----
-
-* Change the value of `additionalProperties` to `true` or remove the line for `additionalProperties` (because `additionalProperties` is `true` by default).
-+
-----
-#%RAML 1.0
-title: Example API Spec
-
-types:
- User:
-   type: object
-   properties:
-     firstName: string
-     lastName: string
-   additionalProperties: true
-   example:
-     firstName: John
-     lastName: Smith
-     age: 49
-----
-
-<<Back to the top>>
-
 [.parser\*Payload-mediaType-minCount#parser\*Payload-mediaType-minCount]
 == Not declaring a media type for a payload
 // Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
@@ -921,8 +922,9 @@ Libraries must be applied by using 'uses'
 
 <<Back to the top>>
 
-
-== Including an example response that contains invalid JSON
+[.parser\*syaml-error#parser\*syaml-error]
+== Problems with syntax
+=== Including an example response that contains invalid JSON
 // APIMF-967
 // Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
 
@@ -959,7 +961,7 @@ title: ExampleRAML
 
 <<Back to the top>>
 
-== Not providing a YAML map when a facet requires one
+=== Not providing a YAML map when a facet requires one
 
 When a facet is described in the RAML 1.0 specification as requiring a map as a value, but the API specification doesn't provide a map, the editor returns the message `YAML map expected`.
 

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -9,7 +9,7 @@ As of January 10, 2019, the API editor (one of the two editors in Design Center'
 After a grace period that lasts at least until January 10, 2020, you will not be able to publish API specifications that generate any violation messages.
 ====
 
-[.schemaInsteadOfType]
+[.parser\*schema-deprecated#parser\*schema-deprecated]
 == Using the `schema` or `schemas` keyword instead of `type` or `types`
 
 The specification for RAML 1.0 replaced the keywords `schema` and `schemas` with `type` and `types`. If you use `schema` or `schemas`, the editor displays one of these warning messages:
@@ -69,6 +69,7 @@ types:
 
 <<Back to the top>>
 
+[.parser\*invalid-type-definition#parser\*invalid-type-definition]
 == Using a reserved name for a type
 
 If you use a reserved name as the name of a type, the editor displays this message:
@@ -104,8 +105,7 @@ types:
 
 <<Back to the top>>
 
-[.parser\*named-example-used-inlined-example]
-
+[.parser\*named-example-used-inlined-example#parser\*named-example-used-inlined-example]
 == Problems with named examples
 // APIMF-907
 
@@ -338,7 +338,7 @@ A single type declaration in an API specification can use only one `!include` ta
 ////
 <<Back to the top>>
 
-
+[.parser\*invalid-fragment-ref#parser\*invalid-fragment-ref]
 == Appending references with hash symbols to filenames in `!include` statements
 // APIMF-834
 
@@ -464,7 +464,7 @@ title: ExampleRAML
 
 
 
-
+[.parser\*expected-module#parser\*expected-module]
 == Referencing libraries by using the `type` key
 // APIMF-1030
 
@@ -591,6 +591,7 @@ types:
 
 <<Back to the top>>
 
+[.parser\*unused-base-uri-parameter#parser\*unused-base-uri-parameter]
 == Declaring a URI parameter that is never used
 // Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
 
@@ -818,7 +819,7 @@ types:
 
 <<Back to the top>>
 
-
+[.parser\*Payload-mediaType-minCount#parser\*Payload-mediaType-minCount]
 == Not declaring a media type for a payload
 // Originally from "Common Problems in Conforming Either to RAML 0.8 or 1.0", which I'm removing.
 
@@ -1002,6 +1003,7 @@ securitySchemes:
 
 <<Back to the top>>
 
+[.parser\*unresolved-reference#parser\*unresolved-reference]
 == Not defining a type that is used
 
 When a type is used, but is not first defined, the editor returns the message `Unresolved reference`.
@@ -1040,7 +1042,7 @@ types:
 
 <<Back to the top>>
 
-
+[.parser\*closed-shape#parser\*closed-shape]
 == Using an unsupported property
 
 This error occurs when a facet or data type is defined as having a specific set of properties, yet an API specification defines the facet with a property that is not in that set. The error can also occur if you use an undefined facet.
@@ -1091,6 +1093,7 @@ version:
 
 <<Back to the top>>
 
+[.resolution\*invalid-type-inheritance#resolution\*invalid-type-inheritance]
 == Merging two types incorrectly
 
 This type of error occurs when you try to perform one of these actions:
@@ -1145,6 +1148,7 @@ For more information, see the section "Union Types" in the xref:https://github.c
 
 <<Back to the top>>
 
+[.parser\*unresolved-parameter#parser\*unresolved-parameter]
 == Declaring an undefined type in a header
 
 This error occurs when a non-existent type is specified in a header. To fix the error, specify a type that is defined in the RAML specification.


### PR DESCRIPTION
These changes add IDs to each section in order to be able to identify the documentation for a given AMF validation. This corresponds to the inline-docs feature for the API Designer.

[JIRA issue](https://www.mulesoft.org/jira/browse/DESIGNER-3646)