### PR TITLE
Updates to the documentation about named examples

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -3,7 +3,7 @@
 * xref:design-modify-raml-specs-conform.adoc[Modify Published RAML API Specifications to Conform Completely to RAML 0.8 or 1.0]
  ** xref:design-common-problems-raml-08.adoc[Common Problems in Conforming to RAML 0.8]
  ** xref:design-common-problems-raml-10.adoc[Common Problems in Conforming to RAML 1.0]
-  *** xref:design-named-examples.adoc[Guide to Using NamedExample Fragments]
+  *** xref:design-named-examples.adoc[Guide to NamedExample Fragments]
  ** xref:design-json-schema-required-error.adoc[Common Errors in Specifying Required Fields in JSON Schemas]
  ** xref:design-scenarios-s6m3-for-published-apis.adoc[Using Published RAML API Specifications in Studio 6.x and Mule Runtime 3.x]
  ** xref:design-scenarios-s7m4-for-published-apis.adoc[Using Published RAML API Specifications in Studio 7.x and Mule Runtime 4.x]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -3,7 +3,7 @@
 * xref:design-modify-raml-specs-conform.adoc[Modify Published RAML API Specifications to Conform Completely to RAML 0.8 or 1.0]
  ** xref:design-common-problems-raml-08.adoc[Common Problems in Conforming to RAML 0.8]
  ** xref:design-common-problems-raml-10.adoc[Common Problems in Conforming to RAML 1.0]
-  *** xref:design-named-examples.adoc[Guide to NamedExample Fragments]
+  *** xref:design-named-examples.adoc[Guide to Named Examples]
  ** xref:design-json-schema-required-error.adoc[Common Errors in Specifying Required Fields in JSON Schemas]
  ** xref:design-scenarios-s6m3-for-published-apis.adoc[Using Published RAML API Specifications in Studio 6.x and Mule Runtime 3.x]
  ** xref:design-scenarios-s7m4-for-published-apis.adoc[Using Published RAML API Specifications in Studio 7.x and Mule Runtime 4.x]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -3,6 +3,7 @@
 * xref:design-modify-raml-specs-conform.adoc[Modify Published RAML API Specifications to Conform Completely to RAML 0.8 or 1.0]
  ** xref:design-common-problems-raml-08.adoc[Common Problems in Conforming to RAML 0.8]
  ** xref:design-common-problems-raml-10.adoc[Common Problems in Conforming to RAML 1.0]
+  *** xref:design-named-examples.adoc[Guide to Using NamedExample Fragments]
  ** xref:design-json-schema-required-error.adoc[Common Errors in Specifying Required Fields in JSON Schemas]
  ** xref:design-scenarios-s6m3-for-published-apis.adoc[Using Published RAML API Specifications in Studio 6.x and Mule Runtime 3.x]
  ** xref:design-scenarios-s7m4-for-published-apis.adoc[Using Published RAML API Specifications in Studio 7.x and Mule Runtime 4.x]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -3,7 +3,7 @@
 * xref:design-modify-raml-specs-conform.adoc[Modify Published RAML API Specifications to Conform Completely to RAML 0.8 or 1.0]
  ** xref:design-common-problems-raml-08.adoc[Common Problems in Conforming to RAML 0.8]
  ** xref:design-common-problems-raml-10.adoc[Common Problems in Conforming to RAML 1.0]
-  *** xref:design-named-examples.adoc[Guide to Named Examples]
+ ** xref:design-named-examples.adoc[Guide to Named Examples in RAML 1.0]
  ** xref:design-json-schema-required-error.adoc[Common Errors in Specifying Required Fields in JSON Schemas]
  ** xref:design-scenarios-s6m3-for-published-apis.adoc[Using Published RAML API Specifications in Studio 6.x and Mule Runtime 3.x]
  ** xref:design-scenarios-s7m4-for-published-apis.adoc[Using Published RAML API Specifications in Studio 7.x and Mule Runtime 4.x]

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -133,10 +133,9 @@ myExample:
     b: 1
 ----
 
-If you do not follow these rules, you will see the messages that are explained in the next two sections.
 
 ////
-6/17/19: Removed this error at the request of Lucas Block. See https://docs.google.com/document/d/1p9Cyycb_Bz2Vv3HNSsmcFAtHohoNLGZbo67rZX6Tou4/edit#heading=h.i7g4n12fr6cm.
+6/21/19: Removed these two errors at the request of Lucas Block. See https://docs.google.com/document/d/1p9Cyycb_Bz2Vv3HNSsmcFAtHohoNLGZbo67rZX6Tou4/edit#heading=h.i7g4n12fr6cm.
 
 === Not using the "examples" facet when referencing to a named example
 
@@ -172,16 +171,14 @@ types:
      examples: !include fragment.raml
 ----
 
-////
+
 
 === Not naming named examples
 
-////
 6/17/19
 In the Google Doc, I asked Lucas this question:
 If there no longer is a warning, can't I simply remove the section "Not naming named examples"?
 
-////
 
 When a named example does not have a name, the editor displays this warning message:
 
@@ -294,6 +291,7 @@ Name:
       a: "b"
       b: 1
 ----
+////
 
 === Naming named examples twice
 

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -290,15 +290,15 @@ Name:
 ----
 ////
 
-=== Naming named examples twice
+=== Naming examples twice
 
-If a named example is named twice, the editor displays this message, where `<name-of-property>` is the name of the property that the named example is an example of:
+If an example is named twice, the editor displays this message, where `<name-of-property>` is the name of the property that the named example is an example of:
 
 ----
 should have required property '<name-of-property>'
 ----
 
-For example, suppose that a specification defines the property `firstName` and links to a NamedExample fragment by giving the named example the name `someName`:
+For example, suppose that a specification defines the property `firstName` and links to a NamedExample fragment by giving the example the name `someName`:
 ----
 #%RAML 1.0
 title: Example API Spec

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -176,10 +176,6 @@ types:
 
 === Not naming named examples
 
-6/17/19
-In the Google Doc, I asked Lucas this question:
-If there no longer is a warning, can't I simply remove the section "Not naming named examples"?
-
 
 When a named example does not have a name, the editor displays this warning message:
 

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -330,6 +330,14 @@ should have required property 'firstName'
 
 To resolve this type of problem, remove either the name in the `examples` facet in the specification or the name in the NamedExample fragment.
 
+If you choose to remove the name from the NamedExample fragment, you must remove the word "NamedExample" from the declaration in the fragment. For example, you would change the NamedExample fragment used in the situation above to look like this:
+
+----
+#%RAML 1.0
+firstName: Martin Gutierrez
+----
+
+
 
 ////
 === Including more than one named example in a single NamedExample fragment

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -135,6 +135,9 @@ myExample:
 
 If you do not follow these rules, you will see the messages that are explained in the next two sections.
 
+////
+6/17/19: Removed this error at the request of Lucas Block. See https://docs.google.com/document/d/1p9Cyycb_Bz2Vv3HNSsmcFAtHohoNLGZbo67rZX6Tou4/edit#heading=h.i7g4n12fr6cm.
+
 === Not using the "examples" facet when referencing to a named example
 
 If you see this violation message in the code editor, then your API specification is incorrectly referencing a named example by using an `example` facet:
@@ -169,7 +172,7 @@ types:
      examples: !include fragment.raml
 ----
 
-
+////
 
 === Not naming named examples
 

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -176,6 +176,13 @@ types:
 
 === Not naming named examples
 
+////
+6/17/19
+In the Google Doc, I asked Lucas this question:
+If there no longer is a warning, can't I simply remove the section "Not naming named examples"?
+
+////
+
 When a named example does not have a name, the editor displays this warning message:
 
 ----
@@ -288,6 +295,40 @@ Name:
       b: 1
 ----
 
+=== Naming named examples twice
+
+If a named example is named twice, the editor displays this message, where `<name-of-property>` is the name of the property that the named example is an example of:
+
+----
+should have required property '<name-of-property>'
+----
+
+For example, suppose that a specification defines the property `firstName` and links to a NamedExample fragment by giving the named example the name `someName`:
+----
+#%RAML 1.0
+title: Example API Spec
+/tiers:
+ post:
+   body:
+     application/json:
+       properties:
+         firstName: string
+       examples:
+         someName: !include ex.raml
+----
+
+If the fragment also names the example that it contains
+////
+6/17/19
+In the Google Doc, I have a question to Lucas about this error:
+What about changing "someFragmentName" to "someName"? Or, alternatively, changing "someName" to "someFragmentName"? Will doing one of those resolve the error?
+In other words, is the error that the example is named twice or is the error that the names are different?
+////
+----
+#%RAML 1.0 NamedExample
+someFragmentName:
+  firstName: Martin Gutierrez
+----
 
 ////
 //=== Including more than one named example in a single NamedExample fragment
@@ -752,6 +793,8 @@ types:
 ----
 
 <<Back to the top>>
+
+
 
 [.parser\*WebAPI-name-minLength#parser\*WebAPI-name-minLength]
 == Not providing a value for the `title` node

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -109,7 +109,7 @@ types:
 == Problems with named examples
 // APIMF-907
 
-To avoid common problems with referencing a named example with an `!include` tag, follow these two rules:
+To avoid common problems with referencing a named example with an `!include` tag, follow these two guidelines:
 
 * In your API specification, use the `examples` facet and only one `!include` tag, as in this example:
 +
@@ -133,6 +133,7 @@ myExample:
     b: 1
 ----
 
+For a more detailed discussion of how to use named examples, see xref:design-named-examples.adoc[Guide to Named Examples].
 
 ////
 6/21/19: Removed these two errors at the request of Lucas Block. See https://docs.google.com/document/d/1p9Cyycb_Bz2Vv3HNSsmcFAtHohoNLGZbo67rZX6Tou4/edit#heading=h.i7g4n12fr6cm.

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -292,7 +292,7 @@ Name:
 
 === Naming examples twice
 
-If an example is named twice, the editor displays this message, where `<name-of-property>` is the name of the property that the named example is an example of:
+If an example is named twice, the editor displays this message:
 
 ----
 should have required property '<name-of-property>'

--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -315,21 +315,24 @@ title: Example API Spec
          someName: !include ex.raml
 ----
 
-If the fragment also names the example that it contains
-////
-6/17/19
-In the Google Doc, I have a question to Lucas about this error:
-What about changing "someFragmentName" to "someName"? Or, alternatively, changing "someName" to "someFragmentName"? Will doing one of those resolve the error?
-In other words, is the error that the example is named twice or is the error that the names are different?
-////
+Further suppose that the NamedExample fragment also names the example, giving it the name `someFragmentName`:
 ----
 #%RAML 1.0 NamedExample
 someFragmentName:
   firstName: Martin Gutierrez
 ----
 
+In this case, the editor would display this message because the parser interprets `someFragmentName` as the name of the property:
+
+----
+should have required property 'firstName'
+----
+
+To resolve this type of problem, remove either the name in the `examples` facet in the specification or the name in the NamedExample fragment.
+
+
 ////
-//=== Including more than one named example in a single NamedExample fragment
+=== Including more than one named example in a single NamedExample fragment
 
 A NamedExample fragment can contain only one example. The following fragment would generate a warning:
 

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -1,1 +1,106 @@
 = Guide to Using NamedExample Fragments
+
+To name one or more example, you must use the `examples` facet. You can name an example either in the `examples` fact or in the NamedExample fragment.
+
+== Naming a single example in the `examples` facet
+
+.api.raml
+----
+#%RAML 1.0
+title: test
+types:
+  A:
+    properties:
+      givenName: string
+      familyName: string
+    examples:
+      fullName: !include fragment.raml
+----
+
+.fragment.raml
+----
+#%RAML 1.0 NamedExample
+givenName: ”Chiaki”
+familyName: "Mukai"
+----
+
+
+== Naming a single example in a NamedExample fragment
+
+.api.raml
+----
+#%RAML 1.0
+title: test
+types:
+  A:
+    properties:
+      givenName: string
+      familyName: string
+    examples: !include fragment.raml
+----
+
+.fragment.raml
+----
+#%RAML 1.0 NamedExample
+fullName:
+  givenName: ”Chiaki”
+  familyName: "Mukai"
+----
+
+== Naming two examples in an `examples` facet
+
+.api.raml
+----
+#%RAML 1.0
+title: test
+types:
+  A:
+    properties:
+      givenName: string
+      familyName: string
+    examples:
+      fullName: !include fragment1.raml
+      otherFullName: !include fragment2.raml
+----
+
+.fragment1.raml
+----
+#%RAML 1.0 NamedExample
+givenName: ”Chiaki”
+familyName: "Mukai"
+----
+
+.fragment2.raml
+----
+#%RAML 1.0 NamedExample
+givenName: "Kyung-won"
+familyName: "Park"
+----
+
+== Naming two examples in a NamedExample fragment
+
+.api.raml
+----
+#%RAML 1.0
+title: test
+types:
+  A:
+    properties:
+      givenName: string
+      familyName: string
+    examples: !include fragment.raml
+----
+
+.fragment.raml
+----
+#%RAML 1.0 NamedExample
+fullName:
+  givenName: ”Chiaki”
+  familyName: "Mukai"
+
+otherFullName:
+  givenName: "Kyung-won"
+  familyName: "Park"
+----
+
+To use one example without naming it, you must use the `example` facet.

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -1,8 +1,10 @@
-= Guide to Using NamedExample Fragments
+= Guide to NamedExample Fragments
 
-To name one or more example, you must use the `examples` facet. You can name an example either in the `examples` fact or in the NamedExample fragment.
+If you want to use more than one example for a type, resource type, or trait, you must name the examples. To name one or more example, you must use the `examples` facet. You can name an example either in the `examples` fact or in the NamedExample fragment.
 
 == Naming a single example in the `examples` facet
+
+The `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
 
 .api.raml
 ----
@@ -19,13 +21,15 @@ types:
 
 .fragment.raml
 ----
-#%RAML 1.0 NamedExample
+#%RAML 1.0
 givenName: ”Chiaki”
 familyName: "Mukai"
 ----
 
 
 == Naming a single example in a NamedExample fragment
+
+The `examples` facet does not name the example. The NamedExample fragment names the example `fullName`.
 
 .api.raml
 ----
@@ -49,6 +53,8 @@ fullName:
 
 == Naming two examples in an `examples` facet
 
+The `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
+
 .api.raml
 ----
 #%RAML 1.0
@@ -65,19 +71,21 @@ types:
 
 .fragment1.raml
 ----
-#%RAML 1.0 NamedExample
+#%RAML 1.0
 givenName: ”Chiaki”
 familyName: "Mukai"
 ----
 
 .fragment2.raml
 ----
-#%RAML 1.0 NamedExample
+#%RAML 1.0
 givenName: "Kyung-won"
 familyName: "Park"
 ----
 
 == Naming two examples in a NamedExample fragment
+
+The `examples` facet does not name the examples.  The NamedExample fragment names the examples `fullName` and `otherFullName`.
 
 .api.raml
 ----

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -7,7 +7,7 @@ To use one example without naming it, you must use the `example` facet.
 
 == Naming a single example in the `examples` facet
 
-The `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
+In the illustration in this section, the `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
 
 .api.raml
 ----
@@ -32,7 +32,7 @@ familyName: "Mukai"
 
 == Naming a single example in a NamedExample fragment
 
-The `examples` facet does not name the example. The NamedExample fragment names the example `fullName`.
+In the illustration in this section, the `examples` facet does not name the example. The NamedExample fragment names the example `fullName`.
 
 .api.raml
 ----
@@ -56,7 +56,7 @@ fullName:
 
 == Naming two examples in an `examples` facet
 
-The `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
+In the illustration in this section, the `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
 
 .api.raml
 ----
@@ -88,7 +88,7 @@ familyName: "Park"
 
 == Naming two examples in a NamedExample fragment
 
-The `examples` facet does not name the examples.  The NamedExample fragment names the examples `fullName` and `otherFullName`.
+In the illustration in this section, the `examples` facet does not name the examples.  The NamedExample fragment names the examples `fullName` and `otherFullName`.
 
 .api.raml
 ----

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -9,7 +9,7 @@ If you want to use one or more named examples for a type, resource type, or trai
 Use the `example` facet only If you want to provide a single, unnamed example.
 
 
-== Naming a single example in the `examples` facet
+== Naming a single example with an `examples` facet
 
 In the sample files in this section, the `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
 
@@ -58,7 +58,7 @@ fullName:
   familyName: "Mukai"
 ----
 
-== Naming two examples in an `examples` facet
+== Naming two examples with an `examples` facet
 
 In the sample files in this section, the `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
 

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -11,7 +11,7 @@ Use the `example` facet only If you want to provide a single, unnamed example.
 
 == Naming a single example with an `examples` facet
 
-In the sample files in this section, the `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
+In the following sample files, the `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
 
 .api.raml
 ----
@@ -36,7 +36,7 @@ familyName: "Mukai"
 
 == Naming a single example in a NamedExample fragment
 
-In the sample files in this section, the `examples` facet does not name the example. The NamedExample fragment names the example `fullName`.
+In the following sample files, the `examples` facet does not name the example. The NamedExample fragment names the example `fullName`.
 
 .api.raml
 ----
@@ -60,7 +60,7 @@ fullName:
 
 == Naming two examples with an `examples` facet
 
-In the sample files in this section, the `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
+In the following sample files, the `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
 
 .api.raml
 ----
@@ -92,7 +92,7 @@ familyName: "Park"
 
 == Naming two examples in a NamedExample fragment
 
-In the sample files in this section, the `examples` facet does not name the examples.  The NamedExample fragment names the examples `fullName` and `otherFullName`.
+In the following sample files, the `examples` facet does not name the examples.  The NamedExample fragment names the examples `fullName` and `otherFullName`.
 
 .api.raml
 ----

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -6,7 +6,7 @@ If you want to use one or more named examples for a type, trait, or resource typ
 
 * To use more than one named example, you must use the `examples` facet when you include the corresponding NamedExample fragments.
 
-Use the `example` facet only If you want to provide a single, unnamed example.
+Use the `example` facet only if you want to provide a single, unnamed example.
 
 
 == Naming a single example for a type by using an `examples` facet

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -1,6 +1,9 @@
-= Guide to NamedExample Fragments
+= Guide to Named Examples
 
-If you want to use more than one example for a type, resource type, or trait, you must name the examples. To name one or more example, you must use the `examples` facet. You can name an example either in the `examples` fact or in the NamedExample fragment.
+If you want to use more than one example for a type, resource type, or trait, you must name the examples. You can also name a single example. When you name examples, you must use the `examples` facet.
+
+To use one example without naming it, you must use the `example` facet.
+
 
 == Naming a single example in the `examples` facet
 
@@ -111,4 +114,106 @@ otherFullName:
   familyName: "Park"
 ----
 
-To use one example without naming it, you must use the `example` facet.
+== Naming an example in the definition of a trait
+
+As in other cases, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
+
+In this case, the example is named in the `examples` facet.
+
+.api.raml
+----
+#%RAML 1.0
+title: test
+traits:
+  myTrait:
+    responses:
+      200:
+        description: desc
+        body:
+          application/json:
+            type:
+              properties:
+                givenName: string
+                familyName: string
+            examples: !include fragment.raml
+
+/end:
+  post:
+    is: myTrait
+----
+
+.fragment.raml
+----
+#%RAML 1.0 NamedExample
+fullName:
+  givenName: ”Chiaki”
+  familyName: "Mukai"
+----
+
+== Naming an example in the definition of a resource type
+
+As in other cases, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
+
+In this case, the example is named in the `examples` facet.
+
+.api.raml
+----
+#%RAML 1.0
+title: test
+resourceTypes:
+  myResourceType:
+    get:
+      body:
+        application/json:
+          type:
+            properties:
+              givenName: string
+              familyName: string
+          examples: <<myParam>>
+
+/end:
+  type:
+    myResourceType:
+----
+
+.fragment.raml
+----
+#%RAML 1.0 NamedExample
+fullName:
+  givenName: ”Chiaki”
+  familyName: "Mukai"
+----
+
+== Using a single, unnamed example
+
+If you do not want to use more than one example and you do not want to name your single example, use the `example` facet instead of the `examples` facet.
+
+Here, the `example` facet includes `fragment1.raml`. Neither the facet nor the fragment names the example. Also, the fragment is not a NamedExample fragment.
+
+If you wanted the `example` facet to point to `fragment2.raml`, you would need to change the filename in the facet. You could not include both fragments at the same time.
+
+.api.raml
+----
+#%RAML 1.0
+title: test
+types:
+  A:
+    properties:
+      givenName: string
+      familyName: string
+   example: !include fragment1.raml
+----
+
+.fragment1.raml
+----
+#%RAML 1.0
+givenName: ”Chiaki”
+familyName: "Mukai"
+----
+
+.fragment2.raml
+----
+#%RAML 1.0
+givenName: "Kyung-won"
+familyName: "Park"
+----

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -1,4 +1,4 @@
-= Guide to Named Examples
+= Guide to Named Examples in RAML 1.0
 
 If you want to use more than one example for a type, resource type, or trait, you must name the examples. You can also name a single example. When you name examples, you must use the `examples` facet.
 

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -118,7 +118,7 @@ otherFullName:
 
 When you name an example in a trait, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
 
-In this case, the example is named in the `examples` facet.
+In this case, the example is named in the NamedExample fragment.
 
 .api.raml
 ----
@@ -154,7 +154,7 @@ fullName:
 
 When you name an example in a resource type, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
 
-In this case, the example is named in the `examples` facet.
+In this case, the example is named in the NamedExample fragment.
 
 .api.raml
 ----

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -116,7 +116,7 @@ otherFullName:
 
 == Naming an example in the definition of a trait
 
-As in other cases, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
+As in the previous sections, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
 
 In this case, the example is named in the `examples` facet.
 
@@ -152,7 +152,7 @@ fullName:
 
 == Naming an example in the definition of a resource type
 
-As in other cases, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
+As in the previous sections, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
 
 In this case, the example is named in the `examples` facet.
 

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -7,7 +7,7 @@ To use one example without naming it, you must use the `example` facet.
 
 == Naming a single example in the `examples` facet
 
-In the illustration in this section, the `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
+In the sample files in this section, the `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
 
 .api.raml
 ----
@@ -32,7 +32,7 @@ familyName: "Mukai"
 
 == Naming a single example in a NamedExample fragment
 
-In the illustration in this section, the `examples` facet does not name the example. The NamedExample fragment names the example `fullName`.
+In the sample files in this section, the `examples` facet does not name the example. The NamedExample fragment names the example `fullName`.
 
 .api.raml
 ----
@@ -56,7 +56,7 @@ fullName:
 
 == Naming two examples in an `examples` facet
 
-In the illustration in this section, the `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
+In the sample files in this section, the `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
 
 .api.raml
 ----
@@ -88,7 +88,7 @@ familyName: "Park"
 
 == Naming two examples in a NamedExample fragment
 
-In the illustration in this section, the `examples` facet does not name the examples.  The NamedExample fragment names the examples `fullName` and `otherFullName`.
+In the sample files in this section, the `examples` facet does not name the examples.  The NamedExample fragment names the examples `fullName` and `otherFullName`.
 
 .api.raml
 ----

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -1,8 +1,12 @@
 = Guide to Named Examples in RAML 1.0
 
-If you want to use more than one example for a type, resource type, or trait, you must name the examples. You can also name a single example. When you name examples, you must use the `examples` facet.
+If you want to use one or more named examples for a type, resource type, or trait in your RAML 1.0 API specification, you must follow these two rules:
 
-To use one example without naming it, you must use the `example` facet.
+* To use a single, named example, you must use the `examples` facet when you include the corresponding NamedExample fragment.
+
+* To use more than one named example, you must use the `examples` facet when you include the corresponding NamedExample fragments.
+
+Use the `example` facet only If you want to provide a single, unnamed example.
 
 
 == Naming a single example in the `examples` facet

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -1,0 +1,1 @@
+= Guide to Using NamedExample Fragments

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -1,6 +1,6 @@
 = Guide to Named Examples in RAML 1.0
 
-If you want to use one or more named examples for a type, resource type, or trait in your RAML 1.0 API specification, you must follow these two rules:
+If you want to use one or more named examples for a type, trait, or resource type in your RAML 1.0 API specification, you must follow these two rules:
 
 * To use a single, named example, you must use the `examples` facet when you include the corresponding NamedExample fragment.
 
@@ -9,7 +9,7 @@ If you want to use one or more named examples for a type, resource type, or trai
 Use the `example` facet only If you want to provide a single, unnamed example.
 
 
-== Naming a single example with an `examples` facet
+== Naming a single example for a type by using an `examples` facet
 
 In the following sample files, the `examples` facet names the example `fullName`. The fragment is not declared as a NamedExample fragment because it does not provide a name.
 
@@ -34,7 +34,7 @@ familyName: "Mukai"
 ----
 
 
-== Naming a single example in a NamedExample fragment
+== Naming a single example for a type by using a NamedExample fragment
 
 In the following sample files, the `examples` facet does not name the example. The NamedExample fragment names the example `fullName`.
 
@@ -58,7 +58,7 @@ fullName:
   familyName: "Mukai"
 ----
 
-== Naming two examples with an `examples` facet
+== Naming two examples for a type by using an `examples` facet
 
 In the following sample files, the `examples` facet names the examples `fullName` and `otherFullName`. The fragments are not declared as NamedExample fragments because they do not provide names.
 
@@ -90,7 +90,7 @@ givenName: "Kyung-won"
 familyName: "Park"
 ----
 
-== Naming two examples in a NamedExample fragment
+== Naming two examples for a type in a NamedExample fragment
 
 In the following sample files, the `examples` facet does not name the examples.  The NamedExample fragment names the examples `fullName` and `otherFullName`.
 

--- a/modules/ROOT/pages/design-named-examples.adoc
+++ b/modules/ROOT/pages/design-named-examples.adoc
@@ -116,7 +116,7 @@ otherFullName:
 
 == Naming an example in the definition of a trait
 
-As in the previous sections, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
+When you name an example in a trait, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
 
 In this case, the example is named in the `examples` facet.
 
@@ -152,7 +152,7 @@ fullName:
 
 == Naming an example in the definition of a resource type
 
-As in the previous sections, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
+When you name an example in a resource type, you can name the example either in the `examples` facet or in a NamedExample fragment. If you choose to name the example in the facet, do not declare the fragment to be a NamedExample fragment.
 
 In this case, the example is named in the `examples` facet.
 


### PR DESCRIPTION
1. I updated the existing doc about named examples to comment out two errors and to add a new error.
2. I created a new topic about naming examples.