### PR TITLE
Docs 5684 toolbar updates mc

### DIFF
--- a/modules/ROOT/pages/fd-publish-app-as-template.adoc
+++ b/modules/ROOT/pages/fd-publish-app-as-template.adoc
@@ -33,7 +33,7 @@ Templates do not include the authentication credentials that are specified for t
 
 == Procedure
 
-. Select Publish Template under the down arrow which is in the top-right corner of the Flow Designer screen.
+. Select *Publish Template* under the down arrow which is in the top-right corner of the Flow Designer screen.
 . Specify a name for the template.
 . Click the *Publish* button.
 

--- a/modules/ROOT/pages/fd-publish-app-as-template.adoc
+++ b/modules/ROOT/pages/fd-publish-app-as-template.adoc
@@ -33,9 +33,9 @@ Templates do not include the authentication credentials that are specified for t
 
 == Procedure
 
-. Click the *Publish* button, which is in the top-right corner of the Flow Designer screen.
+. Select Publish Template under the Down Arrow which is in the top-right corner of the Flow Designer screen.
 . Specify a name for the template.
-. Select Publish Template under the Down Arrow.
+. Click the *Publish* button.
 
 == Result
 

--- a/modules/ROOT/pages/fd-publish-app-as-template.adoc
+++ b/modules/ROOT/pages/fd-publish-app-as-template.adoc
@@ -35,7 +35,7 @@ Templates do not include the authentication credentials that are specified for t
 
 . Click the *Publish* button, which is in the top-right corner of the Flow Designer screen.
 . Specify a name for the template.
-. Click *Publish*.
+. Select Publish Template under the Down Arrow.
 
 == Result
 

--- a/modules/ROOT/pages/fd-publish-app-as-template.adoc
+++ b/modules/ROOT/pages/fd-publish-app-as-template.adoc
@@ -33,7 +33,7 @@ Templates do not include the authentication credentials that are specified for t
 
 == Procedure
 
-. Select Publish Template under the Down Arrow which is in the top-right corner of the Flow Designer screen.
+. Select Publish Template under the down arrow which is in the top-right corner of the Flow Designer screen.
 . Specify a name for the template.
 . Click the *Publish* button.
 

--- a/modules/ROOT/pages/fd-publish-app-as-template.adoc
+++ b/modules/ROOT/pages/fd-publish-app-as-template.adoc
@@ -33,7 +33,7 @@ Templates do not include the authentication credentials that are specified for t
 
 == Procedure
 
-. Select *Publish Template* under the down arrow which is in the top-right corner of the Flow Designer screen.
+. Select *Publish Template* from the drop-down menu which is in the top-right corner of the Flow Designer screen.
 . Specify a name for the template.
 . Click the *Publish* button.
 

--- a/modules/ROOT/pages/fd-tour.adoc
+++ b/modules/ROOT/pages/fd-tour.adoc
@@ -35,7 +35,7 @@ What are data types?:: Data types show the formats in which data are used in a f
 What are dependencies?:: A dependency is any connector, core Mule Runtime component, API, or module that you use in a flow. The first time that you add one of those objects to a flow, you add the current version of it. Every time afterward that you use that object again in the flow, you use the same version of it. From time to time, that object might be updated in Exchange. If you would like your flow to benefit from the update, you can update the version of the object that you are using in your flow.
 . The toolbar
 +
-Here you can undo and redo changes in a project, download a project, change the zoom level of the canvas, run the application for testing, as well as deploy the application to another environment.
+Here you can undo and redo changes in a project, download a project, change the zoom level of the canvas, run the application to test it, or deploy the application to another environment.
 // . The control bar
 // +
 // Here you can run the application for testing, as well as deploy the application to another environment.

--- a/modules/ROOT/pages/fd-tour.adoc
+++ b/modules/ROOT/pages/fd-tour.adoc
@@ -35,10 +35,10 @@ What are data types?:: Data types show the formats in which data are used in a f
 What are dependencies?:: A dependency is any connector, core Mule Runtime component, API, or module that you use in a flow. The first time that you add one of those objects to a flow, you add the current version of it. Every time afterward that you use that object again in the flow, you use the same version of it. From time to time, that object might be updated in Exchange. If you would like your flow to benefit from the update, you can update the version of the object that you are using in your flow.
 . The toolbar
 +
-Here you can undo and redo changes in a project, download a project, and change the zoom level of the canvas.
-. The control bar
-+
-Here you can run the application for testing, as well as deploy the application to another environment.
+Here you can undo and redo changes in a project, download a project, change the zoom level of the canvas, run the application for testing, as well as deploy the application to another environment.
+// . The control bar
+// +
+// Here you can run the application for testing, as well as deploy the application to another environment.
 . The *Problems* and *Logs* tabs
 +
 Click the first tab to see a list of any errors that are in a project. You can click a listed error to open the location in which the error occurs.

--- a/modules/ROOT/pages/import-template.adoc
+++ b/modules/ROOT/pages/import-template.adoc
@@ -36,7 +36,7 @@ For example, if a flow has a card for the Slack connector and posts a message to
 +
 For guidance while you are customizing, refer to the *Notes* section in each card.
 . When you are ready, click *Run* to run the application temporarily and test it. While an application is running, you can trigger its flows and verify that data moves through the flows correctly. After you click *Run*, the application continues to run for 60 hours unless you make changes to it. Whenever you make a change, the application stops running.
-. When you are satisfied with the application, click the *Deploy* button to run the application in a sandbox environment or in a production environment.
+. When you are satisfied with the application, select Deploy Application under the down arrow to run it in a sandbox environment or in a production environment.
 
 == See also
 

--- a/modules/ROOT/pages/import-template.adoc
+++ b/modules/ROOT/pages/import-template.adoc
@@ -36,7 +36,7 @@ For example, if a flow has a card for the Slack connector and posts a message to
 +
 For guidance while you are customizing, refer to the *Notes* section in each card.
 . When you are ready, click *Run* to run the application temporarily and test it. While an application is running, you can trigger its flows and verify that data moves through the flows correctly. After you click *Run*, the application continues to run for 60 hours unless you make changes to it. Whenever you make a change, the application stops running.
-. When you are satisfied with the application, select Deploy Application under the down arrow to run it in a sandbox environment or in a production environment.
+. When you are satisfied with the application, select *Deploy Application* under the down arrow to run it in a sandbox environment or in a production environment.
 
 == See also
 

--- a/modules/ROOT/pages/import-template.adoc
+++ b/modules/ROOT/pages/import-template.adoc
@@ -36,7 +36,7 @@ For example, if a flow has a card for the Slack connector and posts a message to
 +
 For guidance while you are customizing, refer to the *Notes* section in each card.
 . When you are ready, click *Run* to run the application temporarily and test it. While an application is running, you can trigger its flows and verify that data moves through the flows correctly. After you click *Run*, the application continues to run for 60 hours unless you make changes to it. Whenever you make a change, the application stops running.
-. When you are satisfied with the application, select *Deploy Application* under the down arrow to run it in a sandbox environment or in a production environment.
+. When you are satisfied with the application, select *Deploy Application* under the drop-down menu to run it in a sandbox environment or in a production environment.
 
 == See also
 

--- a/modules/ROOT/pages/jump-runtime-manager-task.adoc
+++ b/modules/ROOT/pages/jump-runtime-manager-task.adoc
@@ -6,7 +6,7 @@ endif::[]
 When you run an app in Flow Designer, it appears in the list of running applications in Runtime Manager. You can jump to Runtime Manager from Flow Designer to view runtime information about the app, such as the version of Mule Runtime that it uses, the number of vCores that it uses, and more.
 
 . If the status message in the toolbar above the canvas is `Ready to Run`, click *Run*.
-. Click the three-dots icon to the right of the Down Arrow.
+. Click the three-dots icon to the right of the down arrow.
 . Select *View in Runtime Manager*.
 
 

--- a/modules/ROOT/pages/jump-runtime-manager-task.adoc
+++ b/modules/ROOT/pages/jump-runtime-manager-task.adoc
@@ -6,7 +6,7 @@ endif::[]
 When you run an app in Flow Designer, it appears in the list of running applications in Runtime Manager. You can jump to Runtime Manager from Flow Designer to view runtime information about the app, such as the version of Mule Runtime that it uses, the number of vCores that it uses, and more.
 
 . If the status message in the toolbar above the canvas is `Ready to Run`, click *Run*.
-. Click the three-dots icon to the right of the down arrow.
+. Click the three-dots icon to the right of the drop-down menu.
 . Select *View in Runtime Manager*.
 
 

--- a/modules/ROOT/pages/jump-runtime-manager-task.adoc
+++ b/modules/ROOT/pages/jump-runtime-manager-task.adoc
@@ -6,7 +6,7 @@ endif::[]
 When you run an app in Flow Designer, it appears in the list of running applications in Runtime Manager. You can jump to Runtime Manager from Flow Designer to view runtime information about the app, such as the version of Mule Runtime that it uses, the number of vCores that it uses, and more.
 
 . If the status message in the toolbar above the canvas is `Ready to Run`, click *Run*.
-. Click the three-dots icon to the left of the *Deploy* button.
+. Click the three-dots icon to the right of the Down Arrow.
 . Select *View in Runtime Manager*.
 
 

--- a/modules/ROOT/pages/promote-app-prod-env-design-center.adoc
+++ b/modules/ROOT/pages/promote-app-prod-env-design-center.adoc
@@ -12,7 +12,7 @@ All Mule applications that you create with Flow Designer are created in the Desi
 As you deploy your application, you can change connector configurations and reconnection strategies. You need to do this if there are differences between the Design and target environments that would necessitate such changes.
 
 == Procedure
-. Select *Deploy Application* under the down arrow in the top-right corner of Flow Designer.
+. Select *Deploy Application* under the drop-down menu in the top-right corner of Flow Designer.
 +
 image::deploy-dialog.png[]
 

--- a/modules/ROOT/pages/promote-app-prod-env-design-center.adoc
+++ b/modules/ROOT/pages/promote-app-prod-env-design-center.adoc
@@ -24,7 +24,7 @@ image::deploying-your-project-9cee7.png[]
 
 == What to do next
 
-You can go to Runtime Manager to manage the application. To get there from Flow Designer, click the three-dots icon to the right of the down arrow and select *View in Runtime Manager*.
+You can go to Runtime Manager to manage the application. To get there from Flow Designer, click the three-dots icon to the right of the drop-down menu and select *View in Runtime Manager*.
 
 // April 5, 2019: I'm rewriting this topic today and can't find in our docs any info about securing apps. So, I'll comment this out for now:
 // You can restrict access to the application in the target environment to specific users, if you do not want access available to the general public. To restrict access, your user ID must be an organization administrator in Anypoint Platform.

--- a/modules/ROOT/pages/promote-app-prod-env-design-center.adoc
+++ b/modules/ROOT/pages/promote-app-prod-env-design-center.adoc
@@ -12,7 +12,7 @@ All Mule applications that you create with Flow Designer are created in the Desi
 As you deploy your application, you can change connector configurations and reconnection strategies. You need to do this if there are differences between the Design and target environments that would necessitate such changes.
 
 == Procedure
-. Click *Deploy* in the top-right corner of Flow Designer.
+. Select Deploy Application under the down arrow in the top-right corner of Flow Designer.
 +
 image::deploy-dialog.png[]
 
@@ -24,7 +24,7 @@ image::deploying-your-project-9cee7.png[]
 
 == What to do next
 
-You can go to Runtime Manager to manage the application. To get there from Flow Designer, click the three-dots icon to the left of the *Deploy* button and select *View in Runtime Manager*.
+You can go to Runtime Manager to manage the application. To get there from Flow Designer, click the three-dots icon to the right of the down arrow and select *View in Runtime Manager*.
 
 // April 5, 2019: I'm rewriting this topic today and can't find in our docs any info about securing apps. So, I'll comment this out for now:
 // You can restrict access to the application in the target environment to specific users, if you do not want access available to the general public. To restrict access, your user ID must be an organization administrator in Anypoint Platform.

--- a/modules/ROOT/pages/promote-app-prod-env-design-center.adoc
+++ b/modules/ROOT/pages/promote-app-prod-env-design-center.adoc
@@ -12,7 +12,7 @@ All Mule applications that you create with Flow Designer are created in the Desi
 As you deploy your application, you can change connector configurations and reconnection strategies. You need to do this if there are differences between the Design and target environments that would necessitate such changes.
 
 == Procedure
-. Select Deploy Application under the down arrow in the top-right corner of Flow Designer.
+. Select *Deploy Application* under the down arrow in the top-right corner of Flow Designer.
 +
 image::deploy-dialog.png[]
 

--- a/modules/ROOT/pages/troubleshooting-reference.adoc
+++ b/modules/ROOT/pages/troubleshooting-reference.adoc
@@ -8,7 +8,7 @@ Error messages can appear in two places in Flow Designer:
 * The bottom-right corner of your screen displays error messages in red boxes.
 +
 When you see an error message in this location and you are unable to resolve the error, open a support case for Flow Designer and paste the content of the message into the support case.
-* The top-right corner of your screen displays them next to the *Test* button and down arrow.
+* The top-right corner of your screen displays them next to the *Test* button and the drop-down menu.
 +
 The table below lists all of the error messages that can appear in this location, as well as the actions that you can take to resolve the errors.
 +

--- a/modules/ROOT/pages/troubleshooting-reference.adoc
+++ b/modules/ROOT/pages/troubleshooting-reference.adoc
@@ -8,7 +8,7 @@ Error messages can appear in two places in Flow Designer:
 * The bottom-right corner of your screen displays error messages in red boxes.
 +
 When you see an error message in this location and you are unable to resolve the error, open a support case for Flow Designer and paste the content of the message into the support case.
-* The top-right corner of your screen displays them between the *Run* and *Deploy* buttons.
+* The top-right corner of your screen displays them next to the *Test* and Down Arrow.
 +
 The table below lists all of the error messages that can appear in this location, as well as the actions that you can take to resolve the errors.
 +

--- a/modules/ROOT/pages/troubleshooting-reference.adoc
+++ b/modules/ROOT/pages/troubleshooting-reference.adoc
@@ -8,7 +8,7 @@ Error messages can appear in two places in Flow Designer:
 * The bottom-right corner of your screen displays error messages in red boxes.
 +
 When you see an error message in this location and you are unable to resolve the error, open a support case for Flow Designer and paste the content of the message into the support case.
-* The top-right corner of your screen displays them next to the *Test* button and Down Arrow.
+* The top-right corner of your screen displays them next to the *Test* button and down arrow.
 +
 The table below lists all of the error messages that can appear in this location, as well as the actions that you can take to resolve the errors.
 +

--- a/modules/ROOT/pages/troubleshooting-reference.adoc
+++ b/modules/ROOT/pages/troubleshooting-reference.adoc
@@ -8,7 +8,7 @@ Error messages can appear in two places in Flow Designer:
 * The bottom-right corner of your screen displays error messages in red boxes.
 +
 When you see an error message in this location and you are unable to resolve the error, open a support case for Flow Designer and paste the content of the message into the support case.
-* The top-right corner of your screen displays them next to the *Test* and Down Arrow.
+* The top-right corner of your screen displays them next to the *Test* button and Down Arrow.
 +
 The table below lists all of the error messages that can appear in this location, as well as the actions that you can take to resolve the errors.
 +


### PR DESCRIPTION
UI changes to the toolbar - Deploy and Publish buttons are now selections under the Down Arrow on the toolbar. There is no longer a control bar, only a tool bar.