### PR TITLE
we are listing it by date/time only

### DIFF
--- a/modules/ROOT/pages/fd-project-history.adoc
+++ b/modules/ROOT/pages/fd-project-history.adoc
@@ -7,7 +7,7 @@ endif::[]
 :imagesdir: ../assets/images
 
 You can see a history of changes you make to a project in Flow Designer.
-The saved states are listed by the ID of the user who made the change, by time, by date, and by activity. 
+The saved states are listed by time and date of the changes. 
 
 The name of the saved state is based on the activity you performed when you saved the project.
 


### PR DESCRIPTION
@mcherem unless I'm misunderstanding "The saved states are listed by the ID of the user who made the change, by time, by date, and by activity." I believe the correct statement for this release is that we are listing it by date/time only. For now...