### PR TITLE
there was a typo in the line number 19 and 22

### DIFF
--- a/modules/ROOT/pages/design-common-problems-raml-10.adoc
+++ b/modules/ROOT/pages/design-common-problems-raml-10.adoc
@@ -16,10 +16,10 @@ The following sections describe common errors authors make when writing API spec
 The specification for RAML 1.0 replaced the keywords `schema` and `schemas` with `type` and `types`. If you use `schema` or `schemas`, the editor displays one of these warning messages:
 
 ----
-‘schema' keyword it's deprecated for 1.0 version, should use 'type' instead
+‘schema' keyword it's deprecated for 1.0 version, should use 'schemas' instead
 ----
 ----
-'schemas' keyword it's deprecated for 1.0 version, should use 'types' instead
+'type' keyword it's deprecated for 1.0 version, should use 'types' instead
 ----
 
 For example, the following API specification generates both warning messages:


### PR DESCRIPTION
deprecated keys typo
instead of schemas mentioned as types
instead of type mentioned as schema 

‘schema' keyword it's deprecated for 1.0 version, should use 'type' instead
----
----
'schema' keyword it's deprecated for 1.0 version, should use 'types' instead

changed as below

‘schema' keyword it's deprecated for 1.0 version, should use 'schemas' instead
----
----
'type' keyword it's deprecated for 1.0 version, should use 'types' instead