### PR TITLE
Update design-create-publish-api-fragment.adoc

### DIFF
--- a/modules/ROOT/pages/design-create-publish-api-fragment.adoc
+++ b/modules/ROOT/pages/design-create-publish-api-fragment.adoc
@@ -13,7 +13,7 @@ An API fragment is a RAML document that has a version and an identifier, but is 
 
 * Library
 
-* Type
+* Data Type
 
 * User Documentation
 


### PR DESCRIPTION
There is typo in the fragment you can create in Mulesoft, instead of "Data type" the description says "type".